### PR TITLE
rename vote-api with pipelines-vote-api to match with repo

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -2,22 +2,22 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: vote-api
-  name: vote-api
+    app: pipelines-vote-api
+  name: pipelines-vote-api
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: vote-api
+      app: pipelines-vote-api
   template:
     metadata:
       labels:
-        app: vote-api
+        app: pipelines-vote-api
     spec:
       containers:
         - image: quay.io/openshift-pipeline/vote-api:latest
           imagePullPolicy: Always
-          name: vote-api
+          name: pipelines-vote-api
           ports:
             - containerPort: 9000
               protocol: TCP

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: vote-api
-  name: vote-api
+    app: pipelines-vote-api
+  name: pipelines-vote-api
 spec:
   type: ClusterIP
   ports:
@@ -11,4 +11,4 @@ spec:
       port: 9000
       targetPort: 9000
   selector:
-    app: vote-api
+    app: pipelines-vote-api


### PR DESCRIPTION
Rename deployment and services to `pipelines-vote-api` to match with repo name